### PR TITLE
Preliminary support for m5 and m5d instance types.

### DIFF
--- a/aws/humio-mount-datadir.sh
+++ b/aws/humio-mount-datadir.sh
@@ -1,28 +1,34 @@
 #!/bin/bash
 set -e
-set -x
+#set -x
 
 FSREADY="false"
 
 ### Is there a data volume attached to sdh?
-DISK=`file -s /dev/xvdh | grep "No such file or dir" | wc -l`
+EBSDEV=/dev/xvdh
+DISK=`file -s $EBSDEV | grep "No such file or dir" | wc -l`
 if [ "$DISK" == "1" ]; then
-    echo "ERROR: /dev/xvdh (sdh) does not exist! Attach a data volume to the EC2 instance."
+    # Try the layout used on m5d:
+    EBSDEV=/dev/nvme1n1
+    DISK=`file -s $EBSDEV | grep "No such file or dir" | wc -l`
+fi
+if [ "$DISK" == "1" ]; then
+    echo "ERROR: /dev/xvdh (sdh) and /dev/nvme1n1 does not exist! Attach a data volume to the EC2 instance."
     exit 1
 fi
 
 ### Does the data device contain a filesystem?
-DISK=`file -s /dev/xvdh | grep "ext4 filesystem" | wc -l`
+DISK=`file -s $EBSDEV | grep "ext4 filesystem" | wc -l`
 if [ "$DISK" == "1" ] ; then
     echo "File system exist"
     FSREADY="true"
 fi
 
 ### Does the data device cantain no filesystem?
-DISK=`file -s /dev/xvdh | grep "/dev/xvdh: data" | wc -l`
+DISK=`file -s $EBSDEV | grep "$EBSDEV: data" | wc -l`
 if [ "$DISK" == "1" ] ; then
     echo "No filesystem, formatting disk"
-    mkfs -t ext4 /dev/xvdh
+    mkfs -t ext4 $EBSDEV
     FSREADY="true"
 fi
 
@@ -35,5 +41,41 @@ fi
 ### Mounting the data volume
 echo "Mounting disk at /data"
 mkdir -p /data
-mount /dev/xvdh /data/ || true
+mount $EBSDEV /data/ || true
 
+
+if [ `mount | grep '/humiocache' | wc -l` == "1" ] ; then
+    echo "Cache drive already mounted. Fine."
+else
+    echo "If we find emphemeral disk(s) for cache, mount them now..."
+    if [ "$EBSDEV" == "/dev/nvme1n1" ]; then
+	CACHE_PATTERN="/dev/nvme[23456789]n1"
+    else
+	CACHE_PATTERN="/dev/nvme[0123456789]n1"
+    fi
+
+    CACHE_DRIVES=`ls $CACHE_PATTERN | xargs`
+    if [ "x$CACHE_DRIVES" == "x" ]; then
+	echo "No cache drives detected."
+    else
+	echo "Cache drives detected: $CACHE_DRIVES"
+	sudo apt-get -qy install parted
+	mkdir -p /humiocache || umount /humiocache || true
+	COUNT=`echo $CACHE_DRIVES | wc -w`
+	if [ "$count" == "1" ] ; then
+	    blkdiscard -v $CACHE_DRIVES
+	    mkfs.ext4 -T huge $CACHE_DRIVES
+	    mount $CACHE_DRIVES /humiocache
+	else
+	    for drv in $CACHE_DRIVES; do
+		blkdiscard -v $drv
+		sudo parted -s ${drv} mklabel gpt
+	    done
+	    mdadm --misc --force -S /dev/md7 || true
+	    mdadm --create --metadata=default --run --force --chunk=512 /dev/md7 --level=0 --raid-devices=$COUNT $CACHE_DRIVES
+	    mkfs.ext4 -T huge -E nodiscard /dev/md7
+	    mount /dev/md7 /humiocache
+	    mkdir /humiocache/cache
+	fi
+    fi
+fi

--- a/aws/provision-aws-ubuntu-server.sh
+++ b/aws/provision-aws-ubuntu-server.sh
@@ -11,10 +11,14 @@ systemctl daemon-reload
 systemctl start humio-mount-datadir
 
 ### If we haven't got a humio configuration file we should create a default one
-### matching the about of memory availabe on the instance
+### matching the about of memory available on the instance
 if [ ! -e /etc/humio.conf ]; then
     MEM=`cat /proc/meminfo | grep MemTotal | sed -r 's/MemTotal: +(.*) kB/\1/'`
-    if   (( MEM  > 16000000 )) ; then
+    if   (( MEM  > 64000000 )) ; then
+        echo "HUMIO_JVM_ARGS=-Xmx32G -Xss2M -XX:MaxDirectMemorySize=64G" > /etc/humio.conf
+    elif   (( MEM  > 32000000 )) ; then
+        echo "HUMIO_JVM_ARGS=-Xmx16G -Xss2M -XX:MaxDirectMemorySize=32G" > /etc/humio.conf
+    elif   (( MEM  > 16000000 )) ; then
         echo "HUMIO_JVM_ARGS=-Xmx8G -Xss2M -XX:MaxDirectMemorySize=32G" > /etc/humio.conf
     elif (( MEM  >  8000000 )) ; then
         echo "HUMIO_JVM_ARGS=-Xmx4G -Xss2M -XX:MaxDirectMemorySize=32G" > /etc/humio.conf
@@ -29,4 +33,8 @@ if [ ! -e /etc/humio.conf ]; then
     INSTANCEID=`curl http://169.254.169.254/latest/meta-data/instance-id`
     echo "AUTHENTICATION_METHOD=single-user" >> /etc/humio.conf
     echo "SINGLE_USER_PASSWORD=${INSTANCEID}" >> /etc/humio.conf
+    if [ -d "/humiocache" ]; then
+	echo "CACHE_STORAGE_DIRECTORY=/humiocache" >> /etc/humio.conf
+	echo "CACHE_STORAGE_PERCENTAGE=90" >> /etc/humio.conf
+    fi
 fi

--- a/aws/setup-server.sh
+++ b/aws/setup-server.sh
@@ -24,9 +24,7 @@ EOF
 cp 99-humio.conf /etc/sysctl.d/99-humio.conf
 
 # install docker
-if [ ! -f "/usr/bin/docker" ]; then
-    curl -fsSL https://get.docker.com/ | sh
-fi
+apt-get install -y -qq --no-install-recommends docker.io
 
 # Ensure that a Humio configuration file exists
 if [ ! -e /etc/humio.conf ]; then
@@ -35,4 +33,4 @@ fi
 
 service docker restart
 docker pull humio/humio
-docker run --name=humio -d --restart=always -v /data:/data --net=host --env-file /etc/humio.conf humio/humio
+docker run --name=humio -d --restart=always -v /data:/data -v /humiocache:/humiocache --net=host --env-file /etc/humio.conf humio/humio

--- a/aws/single-server-cloud-formation.json
+++ b/aws/single-server-cloud-formation.json
@@ -28,8 +28,11 @@
         "InstanceType" : {
             "Description" : "Humio EC2 instance type",
             "Type" : "String",
-            "Default" : "m4.xlarge",
-            "AllowedValues" : [ "t2.small", "t2.medium", "t2.large", "m4.large", "m4.xlarge", "m4.2xlarge", "m4.4xlarge", "m4.10xlarge"],
+            "Default" : "i3.8xlarge",
+            "AllowedValues" : [ "t2.small", "t2.medium", "t2.large",
+				"i3.large", "i3.xlarge", "i3.2xlarge", "i3.4xlarge", "i3.8xlarge",
+				"m4.large", "m4.xlarge", "m4.2xlarge", "m4.4xlarge", "m4.10xlarge",
+			        "m5d.large", "m5d.xlarge", "m5d.2xlarge", "m5d.4xlarge", "m5d.12xlarge" ],
             "ConstraintDescription" : "must be a valid EC2 instance type."
         }
     },

--- a/aws/single-server-cloud-formation.json
+++ b/aws/single-server-cloud-formation.json
@@ -22,13 +22,13 @@
         "VolumeSize" : {
             "Description" : "Size (in GB) of the data volume created",
             "Type" : "Number",
-            "Default" : "100"
+            "Default" : "1000"
         },
 
         "InstanceType" : {
             "Description" : "Humio EC2 instance type",
             "Type" : "String",
-            "Default" : "i3.8xlarge",
+            "Default" : "m5d.12xlarge",
             "AllowedValues" : [ "t2.small", "t2.medium", "t2.large",
 				"i3.large", "i3.xlarge", "i3.2xlarge", "i3.4xlarge", "i3.8xlarge",
 				"m4.large", "m4.xlarge", "m4.2xlarge", "m4.4xlarge", "m4.10xlarge",

--- a/aws/single-server-cloud-formation.json
+++ b/aws/single-server-cloud-formation.json
@@ -28,11 +28,13 @@
         "InstanceType" : {
             "Description" : "Humio EC2 instance type",
             "Type" : "String",
-            "Default" : "m5d.12xlarge",
+            "Default" : "c5d.9xlarge",
             "AllowedValues" : [ "t2.small", "t2.medium", "t2.large",
 				"i3.large", "i3.xlarge", "i3.2xlarge", "i3.4xlarge", "i3.8xlarge",
 				"m4.large", "m4.xlarge", "m4.2xlarge", "m4.4xlarge", "m4.10xlarge",
-			        "m5d.large", "m5d.xlarge", "m5d.2xlarge", "m5d.4xlarge", "m5d.12xlarge" ],
+			        "c5d.large", "c5d.xlarge", "c5d.2xlarge", "c5d.4xlarge", "c5d.9xlarge",
+			        "m5d.large", "m5d.xlarge", "m5d.2xlarge", "m5d.4xlarge", "m5d.12xlarge"
+			      ],
             "ConstraintDescription" : "must be a valid EC2 instance type."
         }
     },

--- a/packer/humio-boot.sh
+++ b/packer/humio-boot.sh
@@ -7,7 +7,11 @@ set -x
 
 if [ ! -e /etc/humio.conf ]; then
     MEM=`cat /proc/meminfo | grep MemTotal | sed -r 's/MemTotal: +(.*) kB/\1/'`
-    if   (( MEM  > 16000000 )) ; then
+    if   (( MEM  > 64000000 )) ; then
+        echo "HUMIO_JVM_ARGS=-Xmx32G -Xss2M -XX:MaxDirectMemorySize=64G" > /etc/humio.conf
+    elif   (( MEM  > 32000000 )) ; then
+        echo "HUMIO_JVM_ARGS=-Xmx16G -Xss2M -XX:MaxDirectMemorySize=32G" > /etc/humio.conf
+    elif   (( MEM  > 16000000 )) ; then
         echo "HUMIO_JVM_ARGS=-Xmx8G -Xss2M -XX:MaxDirectMemorySize=32G" > /etc/humio.conf
     elif (( MEM  >  8000000 )) ; then
         echo "HUMIO_JVM_ARGS=-Xmx4G -Xss2M -XX:MaxDirectMemorySize=32G" > /etc/humio.conf
@@ -22,30 +26,40 @@ if [ ! -e /etc/humio.conf ]; then
     INSTANCEID=`curl http://169.254.169.254/latest/meta-data/instance-id`
     echo "AUTHENTICATION_METHOD=single-user" >> /etc/humio.conf
     echo "SINGLE_USER_PASSWORD=${INSTANCEID}" >> /etc/humio.conf
+    if [ -d "/humiocache" ]; then
+	echo "CACHE_STORAGE_DIRECTORY=/humiocache" >> /etc/humio.conf
+	echo "CACHE_STORAGE_PERCENTAGE=90" >> /etc/humio.conf
+    fi
 fi
 
 
 FSREADY="false"
 
 ### Is there a data volume attached to sdh?
-DISK=`file -s /dev/xvdh | grep "No such file or dir" | wc -l`
+EBSDEV=/dev/xvdh
+DISK=`file -s $EBSDEV | grep "No such file or dir" | wc -l`
 if [ "$DISK" == "1" ]; then
-    echo "ERROR: /dev/xvdh (sdh) does not exist! Attach a data volume to the EC2 instance."
+    # Try the layout used on m5d:
+    EBSDEV=/dev/nvme1n1
+    DISK=`file -s $EBSDEV | grep "No such file or dir" | wc -l`
+fi
+if [ "$DISK" == "1" ]; then
+    echo "ERROR: /dev/xvdh (sdh) and /dev/nvme1n1 does not exist! Attach a data volume to the EC2 instance."
     exit 1
 fi
 
 ### Does the data device contain a filesystem?
-DISK=`file -s /dev/xvdh | grep "ext4 filesystem" | wc -l`
+DISK=`file -s $EBSDEV | grep "ext4 filesystem" | wc -l`
 if [ "$DISK" == "1" ] ; then
     echo "File system exist"
     FSREADY="true"
 fi
 
 ### Does the data device cantain no filesystem?
-DISK=`file -s /dev/xvdh | grep "/dev/xvdh: data" | wc -l`
+DISK=`file -s $EBSDEV | grep "$EBSDEV: data" | wc -l`
 if [ "$DISK" == "1" ] ; then
     echo "No filesystem, formatting disk"
-    mkfs -t ext4 /dev/xvdh
+    mkfs -t ext4 $EBSDEV
     FSREADY="true"
 fi
 
@@ -58,7 +72,6 @@ fi
 ### Mounting the data volume
 echo "Mounting disk at /data"
 mkdir -p /data
-mount /dev/xvdh /data/ || true
-
+mount $EBSDEV /data/ || true
 
 docker run --name=humio -d --restart=always -v /data:/data --net=host --env-file /etc/humio.conf humio/humio


### PR DESCRIPTION
Use the local NVME drives if any as a cache, keep the critical files on EBS.

Getting benefit from the cache drive requires the branch `mgr/cache-data-files` in Humio to be merged and released. Without it I think this change just allows using m5 and m5d systems as such.